### PR TITLE
Add constraint: Cabal >= 3.0.

### DIFF
--- a/licensor.cabal
+++ b/licensor.cabal
@@ -37,7 +37,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      Cabal
+      Cabal >= 3.0
     , base >=4.8 && <5
     , containers
     , directory


### PR DESCRIPTION
I haven't researched exactly what the constraint should be, but 3.2.1.0
works for me.

Without this, I got the following, probably caused by trying to build
with Cabal 2 installed:

src/Licensor.hs:69:15: error:
    • No instance for (Distribution.Text.Text LiLicense)
        arising from a use of ‘display’
    • In the first argument of ‘comparing’, namely ‘display’
      In the expression: comparing display
      In an equation for ‘compare’: compare = comparing display

Fixes #27.